### PR TITLE
First attempt at providing ESI auth on Linux

### DIFF
--- a/SDEParser/AtomSmasherESITool/Program.cs
+++ b/SDEParser/AtomSmasherESITool/Program.cs
@@ -240,34 +240,40 @@ namespace AtomSmasherESITool
         {
             string commandLine = "\"" + GetExpectedPath() + "\" \"Install\" \"%1\"";
 
-            object handlerPath = Registry.GetValue(@"HKEY_CLASSES_ROOT\eveauth-atomsmasher\shell\open\command\", "", null);
-
-            if (handlerPath == null || handlerPath.GetType() != typeof(string) || (string)handlerPath != commandLine)
+            try
             {
-                using (StreamWriter sw = new StreamWriter("uri_handler_install.reg"))
+                object handlerPath = Registry.GetValue(@"HKEY_CLASSES_ROOT\eveauth-atomsmasher\shell\open\command\", "", null);
+
+                if (handlerPath == null || handlerPath.GetType() != typeof(string) || (string)handlerPath != commandLine)
                 {
-                    sw.WriteLine("Windows Registry Editor Version 5.00");
-                    sw.WriteLine();
-                    sw.WriteLine("[HKEY_CLASSES_ROOT\\" + AtomSmasherProtocol + "]");
-                    sw.WriteLine("@=\"URL:Atom Smasher Auth Handler\"");
-                    sw.WriteLine("\"URL Protocol\"=\"\"");
-                    sw.WriteLine();
-                    sw.WriteLine("[HKEY_CLASSES_ROOT\\" + AtomSmasherProtocol + "\\shell]");
-                    sw.WriteLine();
-                    sw.WriteLine("[HKEY_CLASSES_ROOT\\" + AtomSmasherProtocol + "\\shell\\open]");
-                    sw.WriteLine();
-                    sw.WriteLine("[HKEY_CLASSES_ROOT\\" + AtomSmasherProtocol + "\\shell\\open\\command]");
-                    sw.WriteLine("@=\"" + commandLine.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\"");
+                    using (StreamWriter sw = new StreamWriter("uri_handler_install.reg"))
+                    {
+                        sw.WriteLine("Windows Registry Editor Version 5.00");
+                        sw.WriteLine();
+                        sw.WriteLine("[HKEY_CLASSES_ROOT\\" + AtomSmasherProtocol + "]");
+                        sw.WriteLine("@=\"URL:Atom Smasher Auth Handler\"");
+                        sw.WriteLine("\"URL Protocol\"=\"\"");
+                        sw.WriteLine();
+                        sw.WriteLine("[HKEY_CLASSES_ROOT\\" + AtomSmasherProtocol + "\\shell]");
+                        sw.WriteLine();
+                        sw.WriteLine("[HKEY_CLASSES_ROOT\\" + AtomSmasherProtocol + "\\shell\\open]");
+                        sw.WriteLine();
+                        sw.WriteLine("[HKEY_CLASSES_ROOT\\" + AtomSmasherProtocol + "\\shell\\open\\command]");
+                        sw.WriteLine("@=\"" + commandLine.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\"");
+                    }
+
+                    Console.WriteLine("Atom Smasher's URI handler isn't registered, or is set to the wrong path.");
+                    Console.WriteLine("I've outputted a 'uri_handler_install.reg' file.  Run it, then try authenticating again.");
+                    Console.WriteLine();
+                    Console.WriteLine("To uninstall the URI handler later, run 'uri_handler_uninstall.reg'.");
+                    Console.WriteLine();
+                    CloseoutCountdown(10);
+
+                    return false;
                 }
-
-                Console.WriteLine("Atom Smasher's URI handler isn't registered, or is set to the wrong path.");
-                Console.WriteLine("I've outputted a 'uri_handler_install.reg' file.  Run it, then try authenticating again.");
-                Console.WriteLine();
-                Console.WriteLine("To uninstall the URI handler later, run 'uri_handler_uninstall.reg'.");
-                Console.WriteLine();
-                CloseoutCountdown(10);
-
-                return false;
+            }
+            catch (System.Security.SecurityException)
+            {
             }
 
             return true;

--- a/SDEParser/ESIHandler/Handler.cs
+++ b/SDEParser/ESIHandler/Handler.cs
@@ -375,7 +375,18 @@ namespace ESIHandler
             }
 
             Console.WriteLine("Pending auth registered, launching browser...");
-            System.Diagnostics.Process.Start(uri);
+
+            try
+            {
+                System.Diagnostics.Process.Start(uri);
+            }
+            catch (System.ComponentModel.Win32Exception)
+            {
+                Console.WriteLine("Failed to launch browser.  Open it manually and visit the following URL:\n");
+                Console.WriteLine(uri);
+                Console.WriteLine("\nAfterwards, copy the response URL and run the following command:");
+                Console.WriteLine("mono SDEParser/AtomSmasherESITool/bin/Release/AtomSmasherESITool.exe Install [RESPONSE URL]");
+            }
         }
 
         static CharacterAuthInfo UnpackToken(AuthToken authToken)


### PR DESCRIPTION
Catch the exceptions that result from missing registry/win32 API, and print instructions to the terminal.
Because if you're running atomsmasher on linux, you're already friends with the terminal.